### PR TITLE
Update to use Lean 3.48 & updated mathlib

### DIFF
--- a/leanpkg.toml
+++ b/leanpkg.toml
@@ -1,8 +1,8 @@
 [package]
 name = "complex_number_game"
 version = "0.1"
-lean_version = "leanprover-community/lean:3.21.0"
+lean_version = "leanprover-community/lean:3.48.0"
 path = "src"
 
 [dependencies]
-mathlib = {git = "https://github.com/leanprover-community/mathlib", rev = "9e4ef8549d1c5eee0f7c0028082afcdeae7b0359"}
+mathlib = {git = "https://github.com/leanprover-community/mathlib", rev = "667de7b2bb7503f64c8761c793fe63f603a31b0c"}


### PR DESCRIPTION
Updated Complex Number Game to use latest Lean 3 and `mathlib`. The "all in one" proof for `comm_ring` broke (presumably because the structure is more complicated in updated `mathlib`, so this PR includes the explicit proofs needed by `comm_ring`.